### PR TITLE
feat: Update message class with increased character limit

### DIFF
--- a/.github/workflows/exercise-03-task-02-deploy.yml
+++ b/.github/workflows/exercise-03-task-02-deploy.yml
@@ -1,0 +1,35 @@
+name: Azure Bicep
+
+on:
+  workflow_dispatch
+
+env:
+  targetEnv: dev
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+    # Checkout code
+    - uses: actions/checkout@main
+
+      # Log into Azure
+    - uses: azure/login@v2.1.1
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        enable-AzPSSession: true
+
+      # Deploy ARM template
+    - name: Run ARM deploy
+      uses: azure/arm-deploy@v1
+      with:
+        subscriptionId: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        resourceGroupName: ${{ secrets.AZURE_RG }}
+        template: ./src/InfrastructureAsCode/main.bicep
+        parameters: environment=${{ env.targetEnv }}

--- a/src/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/src/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -1,5 +1,23 @@
 using System.ComponentModel.DataAnnotations;
 
+/// <summary>
+/// Represents a message.
+/// </summary>
+public class Message
+{
+    /// <summary>
+    /// Gets or sets the ID of the message.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the text of the message.
+    /// </summary>
+    [Required]
+    [DataType(DataType.Text)]
+    [StringLength(250, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+    public string Text { get; set; }
+}
 namespace RazorPagesTestSample.Data
 {
     #region snippet1
@@ -9,7 +27,7 @@ namespace RazorPagesTestSample.Data
 
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        [StringLength(250, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion

--- a/src/InfrastructureAsCode/main.bicep
+++ b/src/InfrastructureAsCode/main.bicep
@@ -8,10 +8,98 @@ var webAppName = '${uniqueString(resourceGroup().id)}-${environment}'
 var appServicePlanName = '${uniqueString(resourceGroup().id)}-mpnp-asp'
 var logAnalyticsName = '${uniqueString(resourceGroup().id)}-mpnp-la'
 var appInsightsName = '${uniqueString(resourceGroup().id)}-mpnp-ai'
-var sku = 'S1'
+var sku = 'P0V3'
 var registryName = '${uniqueString(resourceGroup().id)}mpnpreg'
 var registrySku = 'Standard'
 var imageName = 'techexcel/dotnetcoreapp'
 var startupCommand = ''
 
-// TODO: complete this script
+
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-12-01-preview' = {
+  name: logAnalyticsName
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 90
+    workspaceCapping: {
+      dailyQuotaGb: 1      az account show
+    }
+  }
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02-preview' = {
+  name: appInsightsName
+  location: location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: logAnalyticsWorkspace.id
+  }
+}
+
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2020-11-01-preview' = {
+  name: registryName
+  location: location
+  sku: {
+    name: registrySku
+  }
+  properties: {
+    adminUserEnabled: true
+  }
+}
+
+resource appServicePlan 'Microsoft.Web/serverFarms@2022-09-01' = {
+  name: appServicePlanName
+  location: location
+  kind: 'linux'
+  properties: {
+    reserved: true
+  }
+  sku: {
+    name: sku
+  }
+}
+
+resource appServiceApp 'Microsoft.Web/sites@2020-12-01' = {
+  name: webAppName
+  location: location
+  properties: {
+    serverFarmId: appServicePlan.id
+    httpsOnly: true
+    clientAffinityEnabled: false
+    siteConfig: {
+      linuxFxVersion: 'DOCKER|${containerRegistry.name}.azurecr.io/${uniqueString(resourceGroup().id)}/${imageName}'
+      http20Enabled: true
+      minTlsVersion: '1.2'
+      appCommandLine: startupCommand
+      appSettings: [
+        {
+          name: 'WEBSITES_ENABLE_APP_SERVICE_STORAGE'
+          value: 'false'
+        }
+        {
+          name: 'DOCKER_REGISTRY_SERVER_URL'
+          value: 'https://${containerRegistry.name}.azurecr.io'
+        }
+        {
+          name: 'DOCKER_REGISTRY_SERVER_USERNAME'
+          value: containerRegistry.name
+        }
+        {
+          name: 'DOCKER_REGISTRY_SERVER_PASSWORD'
+          value: containerRegistry.listCredentials().passwords[0].value
+        }
+        {
+          name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
+          value: appInsights.properties.InstrumentationKey
+        }
+        ]
+      }
+    }
+}
+
+output application_name string = appServiceApp.name
+output application_url string = appServiceApp.properties.hostNames[0]
+output container_registry_name string = containerRegistry.name


### PR DESCRIPTION
This pull request includes changes to the `Message` class in the `RazorPagesTestSample` project to improve its documentation and adjust the character limit for messages.

Documentation improvements:

* Added XML documentation comments to the `Message` class and its properties to provide better context and descriptions. (`src/Application/src/RazorPagesTestSample/Data/Message.cs`)

Validation adjustments:

* Increased the maximum allowed length for the `Text` property from 200 to 250 characters to accommodate longer messages. (`src/Application/src/RazorPagesTestSample/Data/Message.cs`)The `Message` class in `RazorPagesTestSample.Data` has been updated to increase the character limit for the `Text` property from 200 to 250. This change allows users to enter longer messages without encountering an error.

Resolves #5