### PR TITLE
chore: Update logAnalyticsWorkspace resource in main.bicep file

### DIFF
--- a/src/InfrastructureAsCode/main.bicep
+++ b/src/InfrastructureAsCode/main.bicep
@@ -24,7 +24,7 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-12
     }
     retentionInDays: 90
     workspaceCapping: {
-      dailyQuotaGb: 1      az account show
+      dailyQuotaGb: 1
     }
   }
 }


### PR DESCRIPTION
This pull request includes a small change to the `src/InfrastructureAsCode/main.bicep` file. The change removes an extraneous command from the `dailyQuotaGb` line in the `logAnalyticsWorkspace` resource.

* [`src/InfrastructureAsCode/main.bicep`](diffhunk://#diff-a705772ad6c700e9d296ea9fb26de5e54a731a73bf57caf1f56f6bb3dbed2869L27-R27): Removed an extraneous `az account show` command from the `dailyQuotaGb` line in the `logAnalyticsWorkspace` resource.